### PR TITLE
Fix for TypeError in ccwrite for Molpro

### DIFF
--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -214,6 +214,8 @@ class JSONIndentEncoder(json.JSONEncoder):
             self.current_indent -= self.indent
             self.current_indent_str = "".join([" " for x in range(self.current_indent)])
             return "{\n" + ",\n".join(output) + "\n" + self.current_indent_str + "}"
+        elif isinstance(o, np.generic):
+            return json.dumps(np.asscalar(o), cls=NumpyAwareJSONEncoder)
         else:
             return json.dumps(o, cls=NumpyAwareJSONEncoder)
 


### PR DESCRIPTION
`ccwrite cjson ~/cclib/data/Molpro/basicMolpro2012/C_bigbasis.out`

gives a `TypeError` with the following trace.

```python
Traceback (most recent call last):
  File "/usr/local/bin/ccwrite", line 90, in <module>
    main()
  File "/usr/local/bin/ccwrite", line 86, in main
    ccwrite(data, outputtype, outputdest, terse, **ccwrite_kwargs)
  File "/usr/local/lib/python3.6/site-packages/cclib/io/ccio.py", line 323, in ccwrite
    output = outputobj.generate_repr()
  File "/usr/local/lib/python3.6/site-packages/cclib/io/cjsonwriter.py", line 149, in generate_repr
    return json.dumps(cjson_dict, cls=JSONIndentEncoder, sort_keys=True, indent=4)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/local/lib/python3.6/site-packages/cclib/io/cjsonwriter.py", line 213, in encode
    str(self.encode(value)))
  File "/usr/local/lib/python3.6/site-packages/cclib/io/cjsonwriter.py", line 213, in encode
    str(self.encode(value)))
  File "/usr/local/lib/python3.6/site-packages/cclib/io/cjsonwriter.py", line 218, in encode
    return json.dumps(o, cls=NumpyAwareJSONEncoder)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.6/site-packages/cclib/io/cjsonwriter.py", line 177, in default
    return json.JSONEncoder.default(self, obj)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'int64' is not JSON serializable
```

It happens while trying to serialize a `numpy.int64` type object to JSON. 
There are other bugs in ccwrite, however this one is specifically limited to Molpro outputs.